### PR TITLE
Add JJB configs to test each collection on ci.centos.org

### DIFF
--- a/jenkins/.gitignore
+++ b/jenkins/.gitignore
@@ -1,0 +1,2 @@
+jenkins_jobs.ini
+local/

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,41 @@
+# Tests on ci.centos.org
+
+This directory contains job configuration files, managed through [Jenkins Job
+Builder](http://ci.openstack.org/jenkins-job-builder/) to run tests for each
+software collection on the [CentOS CI infrastructure](https://ci.centos.org).
+
+*View all tests at [SCLo on ci.centos.org](https://ci.centos.org/view/SCLo/).*
+
+## Pre-requisites
+
+* `virtualenv` command, supplied through the `python-virtualenv` RPM
+
+JJB will be installed into a virtual environment under this directory, so is
+safe to run on any system.
+
+## Testing job modifications
+
+    ./run.sh test -o /tmp/jobs
+
+Check the script exited without any errors, and the XML definitions of the jobs
+will be available in /tmp/jobs.
+
+## Updating jobs
+
+The provided script can update the Jenkins jobs over the API by running JJB.
+
+    ./run.sh update
+
+If you haven't run it before, it will fail with an authentication error:
+
+    jenkins.JenkinsException: Error in request. Possibly authentication failed [401]: Invalid password/token for user
+
+Edit the newly created `jenkins_jobs.ini` and add the username/password for
+access to Jenkins, then re-run the command.  These credentials can be found in
+the home directory on slave01.ci.centos.org.
+
+## Generated jobs
+
+* *Per-collection, per-OS and per-arch tests*: for every SCL/OS/arch
+  combination, a job will be generated to run the full test suite, e.g.
+  `SCLo-git19-rh-C7-x86_64`.

--- a/jenkins/jenkins_jobs.ini.template
+++ b/jenkins/jenkins_jobs.ini.template
@@ -1,0 +1,11 @@
+[jenkins]
+user=
+password=
+url=https://ci.centos.org/
+
+[job_builder]
+ignore_cache=True
+keep_descriptions=False
+include_path=.
+recursive=True
+allow_duplicates=False

--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Install and run Jenkins Job Builder (JJB) and against ci.centos.org to update
+# job definitions for every software collection.
+
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+source ${THISDIR}/../common/functions.sh
+
+# Generate a virtualenv to install JJB into, in a gitignored dir
+if [ ! -d $THISDIR/local ]; then
+  if ! type virtualenv >/dev/null 2>&1; then
+    echo "python-virtualenv must be installed to run this script"
+    exit 1
+  fi
+  virtualenv $THISDIR/local
+fi
+
+source $THISDIR/local/bin/activate
+
+# Install JJB into the venv
+if ! pip show jenkins-job-builder >/dev/null 2>&1; then
+  echo "Installing jenkins-job-builder into an isolated virtualenv..."
+  pip install jenkins-job-builder
+fi
+
+# Generate a JJB config file
+if [ ! -f $THISDIR/jenkins_jobs.ini ]; then
+  cp $THISDIR/jenkins_jobs.ini.template $THISDIR/jenkins_jobs.ini
+  echo "jenkins_jobs.ini generated, please edit and add username/password to update ci.centos.org"
+fi
+
+# Generate jobs from collection list
+OVERRIDE_OS_MAJOR_VERSION=7
+for scl in $(get_collections_list); do
+  namespace=$(get_scl_namespace "$scl")
+  yaml=$THISDIR/yaml/jobs/collections/${scl}-${namespace}.yaml
+  [ -f $yaml ] || \
+    sed "s/%SCL%/${scl}/g; s/%NAMESPACE%/${namespace}/g;" \
+      $THISDIR/yaml/jobs/collections/template > $yaml
+done
+
+# Pass all other arguments through to JJB
+if [ $# -gt 0 ]; then
+  action=$1
+  shift
+  jenkins-jobs --conf $THISDIR/jenkins_jobs.ini $action -r $THISDIR/yaml $*
+else
+  jenkins-jobs $*
+fi
+
+# vim: set ts=2 sw=2 tw=0 :

--- a/jenkins/yaml/builders/cico_install.sh
+++ b/jenkins/yaml/builders/cico_install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+#
+# Installs cicoclient for CentOS CI Duffy access into the workspace
+# http://python-cicoclient.readthedocs.org/en/latest/index.html
+
+if [ ! -d cicoclient ]; then
+    mkdir cicoclient
+    virtualenv cicoclient
+fi
+
+source cicoclient/bin/activate
+
+if ! type cico >/dev/null 2>&1; then
+    pip install python-cicoclient
+fi

--- a/jenkins/yaml/builders/cico_install.yaml
+++ b/jenkins/yaml/builders/cico_install.yaml
@@ -1,0 +1,4 @@
+- builder:
+    name: cico_install
+    builders:
+        - shell: !include-raw: cico_install.sh

--- a/jenkins/yaml/builders/generate_ssh_config.sh
+++ b/jenkins/yaml/builders/generate_ssh_config.sh
@@ -1,0 +1,11 @@
+h=$(head -n 1 host)
+
+cat > ssh_config << EOF
+UserKnownHostsFile /dev/null
+StrictHostKeyChecking no
+User root
+ConnectTimeout 10
+
+Host host
+  Hostname ${h}.ci.centos.org
+EOF

--- a/jenkins/yaml/builders/generate_ssh_config.yaml
+++ b/jenkins/yaml/builders/generate_ssh_config.yaml
@@ -1,0 +1,4 @@
+- builder:
+    name: generate_ssh_config
+    builders:
+        - shell: !include-raw: generate_ssh_config.sh

--- a/jenkins/yaml/defaults/defaults.yaml
+++ b/jenkins/yaml/defaults/defaults.yaml
@@ -1,0 +1,16 @@
+##############################################################################
+####   Defaults
+###############################################################################
+- defaults:
+    description: |
+      This job is automatically updated by Jenkins Job Builder, any manual
+      change will be lost in the next update. If you want to make permanent
+      changes, check out the <a href="https://github.com/sclorg/sclo-ci-tests/">sclo-ci-tests</a> repo.
+    name: global
+    project-type: freestyle
+    concurrent: false
+    logrotate:
+      numToKeep: 10
+    wrappers:
+      - timestamps
+    node: sclo-sig

--- a/jenkins/yaml/jobs/collection.yaml
+++ b/jenkins/yaml/jobs/collection.yaml
@@ -11,6 +11,7 @@
         - cbs-repo:
             tag: 'sclo{release}-{name}-{namespace}-candidate'
             arch: '{arch}'
+        - weekly
     builders:
         - cico_install
         - shell: |

--- a/jenkins/yaml/jobs/collection.yaml
+++ b/jenkins/yaml/jobs/collection.yaml
@@ -1,0 +1,26 @@
+# parameters:
+#   name: software collection name, e.g. httpd24
+#   namespace: SCL namespace/prefix, e.g. rh
+#   release: version of CentOS to test, e.g. 6
+#   arch: architecture of CentOS to test, e.g. x86_64
+- job-template:
+    name: 'SCLo-{name}-{namespace}-C{release}-{arch}'
+    scm:
+        - sclo-ci-tests
+    triggers:
+        - cbs-repo:
+            tag: 'sclo{release}-{name}-{namespace}-candidate'
+            arch: '{arch}'
+    builders:
+        - cico_install
+        - shell: |
+            . cicoclient/bin/activate
+            cico node get -f value --arch {arch} --release {release} --count 1 --api-key $(cat ~/duffy.key) | tee cico.out
+            tail -n 1 cico.out | cut -d ' ' -f 7 > ssid
+            tail -n 1 cico.out | cut -d ' ' -f 2 > host
+        - generate_ssh_config
+        - shell: |
+            scp -F ssh_config -rp tests/ host:tests/
+            ssh -F ssh_config host tests/run.sh {name}
+    publishers:
+        - cico_done

--- a/jenkins/yaml/jobs/collection.yaml
+++ b/jenkins/yaml/jobs/collection.yaml
@@ -6,12 +6,15 @@
 - job-template:
     name: 'SCLo-{name}-{namespace}-C{release}-{arch}'
     scm:
-        - sclo-ci-tests
+        - sclo-ci-tests-collection:
+            collection: '{name}'
+            namespace: '{namespace}'
     triggers:
         - cbs-repo:
             tag: 'sclo{release}-{name}-{namespace}-candidate'
             arch: '{arch}'
         - weekly
+        - scm_fifteen_minutes
     builders:
         - cico_install
         - shell: |

--- a/jenkins/yaml/jobs/collection.yaml
+++ b/jenkins/yaml/jobs/collection.yaml
@@ -23,4 +23,17 @@
             scp -F ssh_config -rp tests/ host:tests/
             ssh -F ssh_config host tests/run.sh {name}
     publishers:
+        - post-tasks:
+            - matches:
+              - log-text: ""
+                operator: AND
+              escalate-status: false
+              run-if-job-successful: false
+              script: |
+                [ -e results ] && rm -rf results/
+                scp -F ssh_config -rp host:/tmp/sclo-results-* results/
         - cico_done
+        - archive:
+            artifacts: 'results/**'
+            allow-empty: true
+            default-excludes: true

--- a/jenkins/yaml/jobs/collections/devassist09-rh.yaml
+++ b/jenkins/yaml/jobs/collections/devassist09-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: devassist09
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/devtoolset-3-rh.yaml
+++ b/jenkins/yaml/jobs/collections/devtoolset-3-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: devtoolset-3
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/devtoolset-4-rh.yaml
+++ b/jenkins/yaml/jobs/collections/devtoolset-4-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: devtoolset-4
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/git19-rh.yaml
+++ b/jenkins/yaml/jobs/collections/git19-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: git19
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/httpd24-rh.yaml
+++ b/jenkins/yaml/jobs/collections/httpd24-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: httpd24
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/mariadb55-rh.yaml
+++ b/jenkins/yaml/jobs/collections/mariadb55-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: mariadb55
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/maven30-rh.yaml
+++ b/jenkins/yaml/jobs/collections/maven30-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: maven30
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/mongodb24-rh.yaml
+++ b/jenkins/yaml/jobs/collections/mongodb24-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: mongodb24
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/mysql55-rh.yaml
+++ b/jenkins/yaml/jobs/collections/mysql55-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: mysql55
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/nginx14-rh.yaml
+++ b/jenkins/yaml/jobs/collections/nginx14-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: nginx14
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/nginx16-rh.yaml
+++ b/jenkins/yaml/jobs/collections/nginx16-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: nginx16
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/nodejs010-rh.yaml
+++ b/jenkins/yaml/jobs/collections/nodejs010-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: nodejs010
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/perl516-rh.yaml
+++ b/jenkins/yaml/jobs/collections/perl516-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: perl516
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/php54-rh.yaml
+++ b/jenkins/yaml/jobs/collections/php54-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: php54
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/php55-rh.yaml
+++ b/jenkins/yaml/jobs/collections/php55-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: php55
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/postgresql92-rh.yaml
+++ b/jenkins/yaml/jobs/collections/postgresql92-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: postgresql92
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/python27-rh.yaml
+++ b/jenkins/yaml/jobs/collections/python27-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: python27
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/python33-rh.yaml
+++ b/jenkins/yaml/jobs/collections/python33-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: python33
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-java-common-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-java-common-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-java-common
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-mariadb100-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-mariadb100-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-mariadb100
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-mongodb26-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-mongodb26-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-mongodb26
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-mysql56-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-mysql56-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-mysql56
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-nginx18-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-nginx18-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-nginx18
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-passenger40-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-passenger40-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-passenger40
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-perl520-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-perl520-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-perl520
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-php56-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-php56-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-php56
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-postgresql94-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-postgresql94-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-postgresql94
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-python34-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-python34-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-python34
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-ror41-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-ror41-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-ror41
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-ruby22-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-ruby22-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-ruby22
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/rh-varnish4-rh.yaml
+++ b/jenkins/yaml/jobs/collections/rh-varnish4-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: rh-varnish4
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/ror40-rh.yaml
+++ b/jenkins/yaml/jobs/collections/ror40-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: ror40
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/ruby193-rh.yaml
+++ b/jenkins/yaml/jobs/collections/ruby193-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: ruby193
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/ruby200-rh.yaml
+++ b/jenkins/yaml/jobs/collections/ruby200-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: ruby200
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/sclo-vagrant1-sclo.yaml
+++ b/jenkins/yaml/jobs/collections/sclo-vagrant1-sclo.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: sclo-vagrant1
+    namespace: sclo
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/template
+++ b/jenkins/yaml/jobs/collections/template
@@ -1,0 +1,9 @@
+- project:
+    name: %SCL%
+    namespace: %NAMESPACE%
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/thermostat1-rh.yaml
+++ b/jenkins/yaml/jobs/collections/thermostat1-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: thermostat1
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/jobs/collections/v8314-rh.yaml
+++ b/jenkins/yaml/jobs/collections/v8314-rh.yaml
@@ -1,0 +1,9 @@
+- project:
+    name: v8314
+    namespace: rh
+    release:
+        - 6
+        - 7
+    arch: x86_64
+    jobs:
+        - 'SCLo-{name}-{namespace}-C{release}-{arch}'

--- a/jenkins/yaml/publishers/cico_done.sh
+++ b/jenkins/yaml/publishers/cico_done.sh
@@ -1,0 +1,2 @@
+source cicoclient/bin/activate
+cico node done --api-key $(cat ~/duffy.key) $(cat ssid)

--- a/jenkins/yaml/publishers/cico_done.yaml
+++ b/jenkins/yaml/publishers/cico_done.yaml
@@ -1,0 +1,10 @@
+- publisher:
+    name: cico_done
+    publishers:
+    - post-tasks:
+        - matches:
+          - log-text: ""
+            operator: AND
+          escalate-status: false
+          run-if-job-successful: false
+          script: !include-raw: cico_done.sh

--- a/jenkins/yaml/scm/sclo-ci-tests-collection.yaml
+++ b/jenkins/yaml/scm/sclo-ci-tests-collection.yaml
@@ -1,0 +1,12 @@
+# parameters:
+#   collection: software collection name, e.g. httpd24
+#   namespace: SCL namespace/prefix, e.g. rh
+- scm:
+    name: sclo-ci-tests-collection
+    scm:
+      - git:
+          url: git://github.com/sclorg/sclo-ci-tests
+          basedir: tests
+          included-regions:
+              - collections/{collection}-{namespace}/.*
+              - PackageLists/{collection}/.*

--- a/jenkins/yaml/scm/sclo-ci-tests.yaml
+++ b/jenkins/yaml/scm/sclo-ci-tests.yaml
@@ -1,0 +1,6 @@
+- scm:
+    name: sclo-ci-tests
+    scm:
+      - git:
+          url: git://github.com/sclorg/sclo-ci-tests
+          basedir: tests

--- a/jenkins/yaml/triggers/cbs-repo.yaml
+++ b/jenkins/yaml/triggers/cbs-repo.yaml
@@ -1,0 +1,9 @@
+- trigger:
+    name: cbs-repo
+    triggers:
+        - pollurl:
+            cron: 'H/10 * * * *'
+            polling-node: sclo-sig
+            urls:
+                - url: 'http://cbs.centos.org/repos/{tag}/{arch}/os/repodata/repomd.xml'
+                  check-date: true

--- a/jenkins/yaml/triggers/scm_fifteen_minutes.yaml
+++ b/jenkins/yaml/triggers/scm_fifteen_minutes.yaml
@@ -1,0 +1,5 @@
+- trigger:
+    name: scm_fifteen_minutes
+    triggers:
+      - pollscm:
+          cron: 'H/15 * * * *'

--- a/jenkins/yaml/triggers/weekly.yaml
+++ b/jenkins/yaml/triggers/weekly.yaml
@@ -1,0 +1,4 @@
+- trigger:
+    name: weekly
+    triggers:
+        - timed: 'H H * * H'


### PR DESCRIPTION
From yesterday's sync-up discussion, here's some work to get SCLs tested on ci.centos.org.  It uses Jenkins Job Builder to generate the job configs remotely, so we can version-control the configs and generate them for every collection automatically.  CentOS are also implementing JJB, so it should be easy to roll these configs into their repo when that's available.

I added example jobs for git19-rh to ci.centos.org (https://ci.centos.org/view/SCLo/), so you can see how they run - the rest can be added with one `./run.sh update` command!

Each job simply runs `./run.sh collection-namespace` on a physical server provisioned with the OS under test using [Duffy](http://wiki.centos.org/QaWiki/CI/Duffy).  I haven't added jobs for the test-released.sh script, but can follow up with this after.
