### PR TITLE
Disable errexit shell option while running scl_source

### DIFF
--- a/collections/mysql-common/basic-usage/create-user.sh
+++ b/collections/mysql-common/basic-usage/create-user.sh
@@ -11,7 +11,7 @@ set -xe
 
 service $SERVICE_NAME restart
 
-source scl_source enable ${ENABLE_SCLS}
+source_scl
 
 mysql -u root <<'EOF'
 CREATE DATABASE IF NOT EXISTS db1;

--- a/collections/postgresql-common/basic-usage/basic-test.sh
+++ b/collections/postgresql-common/basic-usage/basic-test.sh
@@ -11,7 +11,7 @@ set -xe
 
 [ -z "${PGDATA}" ] && exit_fail "Environment variable PGDATA must be set"
 
-source scl_source enable ${ENABLE_SCLS}
+source_scl
 
 export PGPASSWORD=secretpass
 psql -d testdb -U testuser <<EOF

--- a/common/functions.sh
+++ b/common/functions.sh
@@ -84,3 +84,10 @@ exit_fail() {
   exit 1
 }
 
+source_scl() {
+  set -o | egrep -q errexit.*on
+  errexit=$?
+  set +e
+  source scl_source enable ${1-${ENABLE_SCLS}}
+  [ $errexit -eq 0 ] && set -e
+}


### PR DESCRIPTION
scl_source doesn't expect to run with the errexit (set -e) option, causing
it to exit the test script prematurely.

Fixes #8
