### PR TITLE
get vagrant tests passing

### DIFF
--- a/collections/sclo-vagrant1-sclo/enabled_tests
+++ b/collections/sclo-vagrant1-sclo/enabled_tests
@@ -1,5 +1,6 @@
 install
 vagrant-up
+vagrant-up-c6
 install-all-pkgs
 uninstall
 validate-pkg-list

--- a/collections/sclo-vagrant1-sclo/vagrant-up-c6/Vagrantfile
+++ b/collections/sclo-vagrant1-sclo/vagrant-up-c6/Vagrantfile
@@ -1,0 +1,10 @@
+Vagrant.configure("2") do |config|
+  config.vm.define :base do |base|
+    base.vm.box = "centos/6"
+    base.vm.provider :libvirt do |domain|
+      domain.memory = 1024
+      domain.cpus = 1
+    end
+  end
+end
+

--- a/collections/sclo-vagrant1-sclo/vagrant-up-c6/run.sh
+++ b/collections/sclo-vagrant1-sclo/vagrant-up-c6/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+
+# we need to run this as root
+
+yum -y install git qemu-kvm
+service libvirtd start
+syncdir=$(mktemp -d /tmp/sync-XXXXXX)
+git clone https://github.com/CentOS/sig-core-t_functional $syncdir
+cp $THISDIR/Vagrantfile $syncdir
+chmod u+x $THISDIR/vagrant_test.sh
+scl enable sclo-vagrant1 "$THISDIR/vagrant_test.sh $syncdir"
+exit $?

--- a/collections/sclo-vagrant1-sclo/vagrant-up-c6/vagrant_test.sh
+++ b/collections/sclo-vagrant1-sclo/vagrant-up-c6/vagrant_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ] ; then
+  echo "Usage: `basename $0` <dir-with-VagrantFile>"
+  exit 1
+fi
+
+cd $1
+
+set -xe
+
+vagrant up
+vagrant ssh -c 'cd /vagrant; sudo env "PATH=$PATH" ./runtests.sh p_ruby'

--- a/collections/sclo-vagrant1-sclo/vagrant-up/run.sh
+++ b/collections/sclo-vagrant1-sclo/vagrant-up/run.sh
@@ -4,9 +4,9 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 # we need to run this as root
 
+yum -y install git qemu-kvm
 service libvirtd start
 syncdir=$(mktemp -d /tmp/sync-XXXXXX)
-yum -y install git
 git clone https://github.com/CentOS/sig-core-t_functional $syncdir
 cp $THISDIR/Vagrantfile $syncdir
 chmod u+x $THISDIR/vagrant_test.sh

--- a/collections/sclo-vagrant1-sclo/vagrant-up/vagrant_test.sh
+++ b/collections/sclo-vagrant1-sclo/vagrant-up/vagrant_test.sh
@@ -10,4 +10,4 @@ cd $1
 set -xe
 
 vagrant up
-vagrant ssh -c 'cd sync; sudo env "PATH=$PATH" ./runtests.sh p_ruby'
+vagrant ssh -c 'cd /vagrant; sudo env "PATH=$PATH" ./runtests.sh p_ruby'


### PR DESCRIPTION
The present test didnt ensure a hyper-visor was available, we fix that by ensuring qemu-kvm is available; the kvm module should already be present, and as long as the libvirtd process starts after qemu-kvm is present, things should be fine.

Additionally, we now use the /vagrant sync folder as defined as best practise upstream in the Vagrant communities, so change the test worker to execute from there instead of the old ~/sync/ directory.
