### PR TITLE
devtoolset-6: Test only MAJOR version of GCC

### DIFF
--- a/collections/devtoolset-6-rh/compile-postgresql/run.sh
+++ b/collections/devtoolset-6-rh/compile-postgresql/run.sh
@@ -22,8 +22,8 @@ scl enable $INSTALL_SCLS - <<"EOF"
   cd postgresql-9.4.4
   ./configure --without-readline --without-zlib
   make
-  gccver=$(strings -a ./src/backend/postgres | grep -oe "compiled by.*GCC) \([0-9]*\.[0-9]*\.\)" | sed -e 's/.*[[:space:]]//')
-  [ "${gccver}" != "6.2." ] && echo "Wrong GCC version found in postgres binary: ${gccver}" && exit 1
+  gccver=$(strings -a ./src/backend/postgres | grep -oe "compiled by.*GCC) \([0-9]*\.\)" | sed -e 's/.*[[:space:]]//')
+  [ "${gccver}" != "6." ] && echo "Wrong GCC version found in postgres binary: ${gccver}" && exit 1
   popd
 EOF
 


### PR DESCRIPTION
The test starts to fail with new MINOR release of GCC.

For the assurance that the collection's GCC is used, the MAJOR version number is enough (4 on CentOS 7, 6 in collection).