### PR TITLE
Add End-of-Life marks to collection lists

### DIFF
--- a/PackageLists/collections-list-rh-el6
+++ b/PackageLists/collections-list-rh-el6
@@ -1,23 +1,23 @@
-devassist09
-devtoolset-3
+devassist09 EOL
+devtoolset-3 EOL
 devtoolset-4
 devtoolset-6
 devtoolset-7
-git19
+git19 EOL
 httpd24
-mariadb55
-maven30
-mongodb24
-mysql55
-nginx14
-nginx16
-nodejs010
-perl516
-php54
-php55
-postgresql92
+mariadb55 EOL
+maven30 EOL
+mongodb24 EOL
+mysql55 EOL
+nginx14 EOL
+nginx16 EOL
+nodejs010 EOL
+perl516 EOL
+php54 EOL
+php55 EOL
+postgresql92 EOL
 python27
-python33
+python33 EOL
 rh-git29
 rh-java-common
 rh-mariadb100
@@ -55,8 +55,8 @@ rh-ruby24
 rh-scala210
 rh-thermostat16
 rh-varnish4
-ror40
-ruby193
-ruby200
-thermostat1
+ror40 EOL
+ruby193 EOL
+ruby200 EOL
+thermostat1 EOL
 v8314

--- a/PackageLists/collections-list-rh-el7
+++ b/PackageLists/collections-list-rh-el7
@@ -1,25 +1,25 @@
-devassist09
-devtoolset-3
+devassist09 EOL
+devtoolset-3 EOL
 devtoolset-4
 devtoolset-6
 devtoolset-7
-git19
+git19 EOL
 go-toolset-7
 httpd24
 llvm-toolset-7
-mariadb55
-maven30
-mongodb24
-mysql55
-nginx14
-nginx16
-nodejs010
-perl516
-php54
-php55
-postgresql92
+mariadb55 EOL
+maven30 EOL
+mongodb24 EOL
+mysql55 EOL
+nginx14 EOL
+nginx16 EOL
+nodejs010 EOL
+perl516 EOL
+php54 EOL
+php55 EOL
+postgresql92 EOL
 python27
-python33
+python33 EOL
 rh-eclipse46
 rh-git29
 rh-java-common
@@ -63,9 +63,9 @@ rh-scala210
 rh-thermostat16
 rh-varnish4
 rh-varnish5
-ror40
-ruby193
-ruby200
+ror40 EOL
+ruby193 EOL
+ruby200 EOL
 rust-toolset-7
-thermostat1
+thermostat1 EOL
 v8314

--- a/common/functions.sh
+++ b/common/functions.sh
@@ -23,7 +23,7 @@ get_depended_collections() {
 
 # get list of all collections
 get_collections_list() {
-  cat "`dirname ${BASH_SOURCE[0]}`"/../PackageLists/collections-list-*-el`os_major_version` | strip_comments
+  cat "`dirname ${BASH_SOURCE[0]}`"/../PackageLists/collections-list-*-el`os_major_version` | strip_comments | cut -d' ' -f1
 }
 
 # returns `rh` or `sclo` as output or exits if collections does not exists in the list
@@ -33,7 +33,7 @@ get_collections_list() {
 get_scl_namespace() {
   el_version=${2-`os_major_version`}
   for namespace in rh sclo ; do
-    grep -e "^[[:space:]]*$1[[:space:]]*$" "`dirname ${BASH_SOURCE[0]}`"/../PackageLists/collections-list-$namespace-el$el_version >/dev/null
+    grep -e "$1" "`dirname ${BASH_SOURCE[0]}`"/../PackageLists/collections-list-$namespace-el$el_version >/dev/null
     [ $? -eq 0 ] && echo "$namespace" && return 0
   done
   echo "ERROR: collection ${1} not found in PackageLists/collections-list-{rh,sclo}-el$el_version" >&2

--- a/common/functions.sh
+++ b/common/functions.sh
@@ -33,7 +33,8 @@ get_collections_list() {
 get_scl_namespace() {
   el_version=${2-`os_major_version`}
   for namespace in rh sclo ; do
-    grep -e "$1" "`dirname ${BASH_SOURCE[0]}`"/../PackageLists/collections-list-$namespace-el$el_version >/dev/null
+    # Choose only exact name of the collection; i.e. mysql55, not sclo-mysql55
+    grep -e "^[[:space:]]*$1[[:space:]]*" "`dirname ${BASH_SOURCE[0]}`"/../PackageLists/collections-list-$namespace-el$el_version >/dev/null
     [ $? -eq 0 ] && echo "$namespace" && return 0
   done
   echo "ERROR: collection ${1} not found in PackageLists/collections-list-{rh,sclo}-el$el_version" >&2


### PR DESCRIPTION
This commit adds simple EOL marks to the collections that are considered to be
End-of-Life (according to [the wiki](https://wiki.centos.org/SpecialInterestGroup/SCLo/CollectionsList).)

It also edits the two functions that deal with the lists to ignore those marks.

## Testing

I have tested the changes by editing the `run-all-tests.sh` file:

```patch
-  ${THISDIR}/collections/${scl}-$(get_scl_namespace "$scl")/run.sh "$repo_type"
+  echo ${THISDIR}/collections/${scl}-$(get_scl_namespace "$scl")/run.sh "$repo_type"
```

Then I run the adjusted script in both `master` and `eol-marks` branches and
compared the results -- found none.

```sh
$ git checkout $branch
$ ./run-all-tests.sh >test-run-$branch.txt

...

$ diff -u test-run-{master,eol-marks}.txt
```